### PR TITLE
검색 페이지 기능 구현

### DIFF
--- a/src/pages/search/SearchPage.jsx
+++ b/src/pages/search/SearchPage.jsx
@@ -76,8 +76,6 @@ const SearchResult = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-
-  background-color: yellow;
 `;
 
 const Button = styled.div`
@@ -92,6 +90,7 @@ const Button = styled.div`
   cursor: pointer;
   background-color: #0d6b38;
   flex-shrink: 0;
+  opacity: ${(props) => (props.active ? `1` : `0.7`)};
 
   span {
     color: #f0f0f0;
@@ -172,20 +171,40 @@ const SearchPage = () => {
     }
   };
 
-  const handleFriendRequest = async (index) => {
+  const sendFriendRequest = async (friendId) => {
     const accessToken = localStorage.getItem('accessToken');
-    const friendToRequest = searchResult[index];
 
     try {
       const response = await axios.post(
         `/api/friend/add`,
         {
-          id: friendToRequest.id,
+          id: friendId,
         },
         {
           headers: { Authorization: `Bearer ${accessToken}` },
         }
       );
+
+      if (response.status === 200) {
+        handleSearch();
+      } else {
+        // console.error('Unexpected response:', response);
+      }
+    } catch (error) {
+      // console.error('Error sending friend request:', error);
+    }
+  };
+
+  const cancelFriendRequest = async (friendId) => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    try {
+      const response = await axios.delete(`/api/friend/add/cancel`, {
+        data: {
+          id: friendId,
+        },
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
 
       if (response.status === 200) {
         handleSearch();
@@ -232,11 +251,12 @@ const SearchPage = () => {
               accountId={result.accountId}
             />
             {result.friendshipStatus === `UNFRIEND` ? (
-              <Button
-                onClick={() => handleFriendRequest(idx)}
-                friendshipStatus={result.friendshipStatus}
-              >
+              <Button active onClick={() => sendFriendRequest(result.id)}>
                 <span>친구 신청</span>
+              </Button>
+            ) : result.friendshipStatus === `SENT` ? (
+              <Button onClick={() => cancelFriendRequest(result.id)}>
+                <span>대기 중...</span>
               </Button>
             ) : result.friendshipStatus !== `SELF` ? (
               <FriendshipStatusBox friendshipStatus={result.friendshipStatus}>


### PR DESCRIPTION
## 📟 연결된 이슈
close #16 

## 👷 작업한 내용
- 검색 페이지에서 친구 요청 상태를 표시하는 컴포넌트를 `friendshipStatus` 값에 따라 렌더링하는 부분을 리팩토링했습니다.
- 친구 요청을 보내는 API에서 `accountId`가 아닌 `id`를 이용해서 요청하도록 바뀐 내용에 따라 요청 부분을 수정했습니다.
- 이미 친구 요청을 한 경우 토글 시 친구 요청 취소 기능을 수행하도록 API를 연결했습니다.

## 🚨 참고 사항
- Axios에서 DELETE 요청을 보내는 경우, JSON 데이터를 포함하는 방식이 기존 코드와 살짝 다른 형식을 요구합니다.
이를 처리하지 않았을 때 410번 상태 코드를 반환하므로, 아래 링크를 참고해서 해당 형식을 만족해야 할 필요가 있습니다.
https://velog.io/@bigbrothershin/Axios-delete-요청-시-body에-데이터-넣는-법

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|친구 요청 전|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/59dcc831-40f8-4584-bc3e-1d3576105438" height="600px" />|
|친구 요청 후|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/1fc16a48-a227-4463-b407-6699e2055e68" height="600px" />|