### PR TITLE
마이 페이지 기능 구현

### DIFF
--- a/src/components/account/WithdrawModal.jsx
+++ b/src/components/account/WithdrawModal.jsx
@@ -80,9 +80,6 @@ const WithdrawModal = ({ setShowModal }) => {
   const handleWithdraw = async () => {
     const accessToken = localStorage.getItem('accessToken');
 
-    alert('탈퇴 시도');
-    return;
-
     try {
       const response = await axios.delete(`/api/user`, {
         headers: { Authorization: `Bearer ${accessToken}` },

--- a/src/components/account/WithdrawModal.jsx
+++ b/src/components/account/WithdrawModal.jsx
@@ -1,0 +1,115 @@
+import styled from 'styled-components';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const ModalBackground = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 2000;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const ModalOverlay = styled.div`
+  position: relative;
+  max-width: calc(100% - 6rem);
+
+  display: flex;
+  flex-direction: column;
+  row-gap: 1.69rem;
+  padding: 2.5rem 2.37rem 1.87rem;
+
+  border-radius: 0.625rem;
+  background-color: #fff;
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+
+  z-index: 1000;
+`;
+
+const Title = styled.div`
+  position: relative;
+  width: 100%;
+
+  color: #333;
+  font-family: 'Apple SD Gothic Neo';
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+`;
+
+const ButtonContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Button = styled.div`
+  width: 5.75rem;
+  height: 2.1875rem;
+  flex-shrink: 0;
+  border-radius: 1rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  cursor: pointer;
+  background-color: ${(props) => (props.warning ? `#C23952` : `#EAEAEA`)};
+
+  span {
+    color: ${(props) => (props.warning ? `#fff` : `#000`)};
+    font-family: 'Apple SD Gothic Neo';
+    font-size: 0.875rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+  }
+`;
+
+const WithdrawModal = ({ setShowModal }) => {
+  const navigate = useNavigate();
+
+  const handleWithdraw = async () => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    alert('탈퇴 시도');
+    return;
+
+    try {
+      const response = await axios.delete(`/api/user`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      localStorage.clear();
+      navigate(`/login`);
+    } catch (error) {
+      console.error('Error trying withdrawal:', error);
+    }
+  };
+
+  return (
+    <ModalBackground>
+      <ModalOverlay>
+        <Title>정말로 회원 탈퇴 하시겠습니까?</Title>
+        <ButtonContainer>
+          <Button warning onClick={handleWithdraw}>
+            <span>탈퇴하기</span>
+          </Button>
+          <Button onClick={() => setShowModal(false)}>
+            <span>취소</span>
+          </Button>
+        </ButtonContainer>
+      </ModalOverlay>
+    </ModalBackground>
+  );
+};
+
+export default WithdrawModal;

--- a/src/pages/mypage/AccountPage.jsx
+++ b/src/pages/mypage/AccountPage.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { useLoaderData } from 'react-router-dom';
 
-import TabBar from '@components/common/TabBar';
+import WithdrawModal from '@components/account/WithdrawModal';
 
 const Layout = styled.div`
   width: 100%;
@@ -103,19 +103,26 @@ const ActionMenu = styled.div`
   }
 `;
 
+const PopupLayout = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+`;
+
 const AccountPage = () => {
   const [searchEnabled, setSearchEnabled] = useState(true);
+  const [showModal, setShowModal] = useState(false);
 
   const toggleSearchEnabled = () => {
     setSearchEnabled((searchEnabled) => !searchEnabled);
   };
 
-  const onClickWithdraw = () => {
-    alert('탈퇴 기능 구현 중...');
-  };
-
   return (
     <Layout>
+      <PopupLayout>
+        {showModal && <WithdrawModal setShowModal={setShowModal} />}
+      </PopupLayout>
+
       <Top>
         <h1>계정 설정</h1>
 
@@ -260,13 +267,11 @@ const AccountPage = () => {
 
       <section>
         <MenuBox>
-          <ActionMenu onClick={onClickWithdraw}>
+          <ActionMenu onClick={() => setShowModal(true)}>
             <span className="important__menu">회원 탈퇴</span>
           </ActionMenu>
         </MenuBox>
       </section>
-
-      <TabBar />
     </Layout>
   );
 };

--- a/src/pages/mypage/AccountPage.jsx
+++ b/src/pages/mypage/AccountPage.jsx
@@ -162,9 +162,9 @@ const AccountPage = () => {
                       width="36"
                       height="22"
                       filterUnits="userSpaceOnUse"
-                      color-interpolation-filters="sRGB"
+                      colorInterpolationFilters="sRGB"
                     >
-                      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                      <feFlood floodOpacity="0" result="BackgroundImageFix" />
                       <feBlend
                         mode="normal"
                         in="SourceGraphic"

--- a/src/pages/mypage/AccountPage.jsx
+++ b/src/pages/mypage/AccountPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { useLoaderData } from 'react-router-dom';
@@ -104,8 +104,11 @@ const ActionMenu = styled.div`
 `;
 
 const AccountPage = () => {
-  const { response } = useLoaderData();
-  console.log(response);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+
+  const toggleSearchEnabled = () => {
+    setSearchEnabled((searchEnabled) => !searchEnabled);
+  };
 
   const onClickWithdraw = () => {
     alert('탈퇴 기능 구현 중...');
@@ -138,60 +141,119 @@ const AccountPage = () => {
         <MenuBox>
           <ActionMenu>
             <span>아이디 검색 허용</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="36"
-              height="20"
-              viewBox="0 0 36 20"
-              fill="none"
-            >
-              <g filter="url(#filter0_i_1311_4124)">
-                <rect width="36" height="20" rx="10" fill="#D9D9D9" />
-              </g>
-              <circle cx="10" cy="10" r="8" fill="white" />
-              <defs>
-                <filter
-                  id="filter0_i_1311_4124"
-                  x="0"
-                  y="0"
+            <div onClick={toggleSearchEnabled}>
+              {searchEnabled ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
                   width="36"
-                  height="22"
-                  filterUnits="userSpaceOnUse"
-                  colorInterpolationFilters="sRGB"
+                  height="20"
+                  viewBox="0 0 36 20"
+                  fill="none"
                 >
-                  <feFlood floodOpacity="0" result="BackgroundImageFix" />
-                  <feBlend
-                    mode="normal"
-                    in="SourceGraphic"
-                    in2="BackgroundImageFix"
-                    result="shape"
-                  />
-                  <feColorMatrix
-                    in="SourceAlpha"
-                    type="matrix"
-                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-                    result="hardAlpha"
-                  />
-                  <feOffset dy="2" />
-                  <feGaussianBlur stdDeviation="1" />
-                  <feComposite
-                    in2="hardAlpha"
-                    operator="arithmetic"
-                    k2="-1"
-                    k3="1"
-                  />
-                  <feColorMatrix
-                    type="matrix"
-                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
-                  />
-                  <feBlend
-                    mode="normal"
-                    in2="shape"
-                    result="effect1_innerShadow_1311_4124"
-                  />
-                </filter>
-              </defs>
-            </svg>
+                  <g filter="url(#filter0_i_1496_6479)">
+                    <rect width="36" height="20" rx="10" fill="#2C8253" />
+                  </g>
+                  <circle cx="26" cy="10" r="8" fill="white" />
+                  <defs>
+                    <filter
+                      id="filter0_i_1496_6479"
+                      x="0"
+                      y="0"
+                      width="36"
+                      height="22"
+                      filterUnits="userSpaceOnUse"
+                      color-interpolation-filters="sRGB"
+                    >
+                      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                      <feBlend
+                        mode="normal"
+                        in="SourceGraphic"
+                        in2="BackgroundImageFix"
+                        result="shape"
+                      />
+                      <feColorMatrix
+                        in="SourceAlpha"
+                        type="matrix"
+                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                        result="hardAlpha"
+                      />
+                      <feOffset dy="2" />
+                      <feGaussianBlur stdDeviation="1" />
+                      <feComposite
+                        in2="hardAlpha"
+                        operator="arithmetic"
+                        k2="-1"
+                        k3="1"
+                      />
+                      <feColorMatrix
+                        type="matrix"
+                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+                      />
+                      <feBlend
+                        mode="normal"
+                        in2="shape"
+                        result="effect1_innerShadow_1496_6479"
+                      />
+                    </filter>
+                  </defs>
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="36"
+                  height="20"
+                  viewBox="0 0 36 20"
+                  fill="none"
+                >
+                  <g filter="url(#filter0_i_1311_4124)">
+                    <rect width="36" height="20" rx="10" fill="#D9D9D9" />
+                  </g>
+                  <circle cx="10" cy="10" r="8" fill="white" />
+                  <defs>
+                    <filter
+                      id="filter0_i_1311_4124"
+                      x="0"
+                      y="0"
+                      width="36"
+                      height="22"
+                      filterUnits="userSpaceOnUse"
+                      colorInterpolationFilters="sRGB"
+                    >
+                      <feFlood floodOpacity="0" result="BackgroundImageFix" />
+                      <feBlend
+                        mode="normal"
+                        in="SourceGraphic"
+                        in2="BackgroundImageFix"
+                        result="shape"
+                      />
+                      <feColorMatrix
+                        in="SourceAlpha"
+                        type="matrix"
+                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                        result="hardAlpha"
+                      />
+                      <feOffset dy="2" />
+                      <feGaussianBlur stdDeviation="1" />
+                      <feComposite
+                        in2="hardAlpha"
+                        operator="arithmetic"
+                        k2="-1"
+                        k3="1"
+                      />
+                      <feColorMatrix
+                        type="matrix"
+                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+                      />
+                      <feBlend
+                        mode="normal"
+                        in2="shape"
+                        result="effect1_innerShadow_1311_4124"
+                      />
+                    </filter>
+                  </defs>
+                </svg>
+              )}
+            </div>
           </ActionMenu>
         </MenuBox>
       </section>

--- a/src/pages/mypage/EditProfilePage.jsx
+++ b/src/pages/mypage/EditProfilePage.jsx
@@ -284,6 +284,7 @@ function EditProfilePage() {
       }
 
       const formJson = JSON.stringify({
+        image_modified: isImageChanged,
         accountId: userData.accountId,
         nickname: userData.nickname,
       });

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -16,6 +16,13 @@ const Layout = styled.div`
     display: flex;
     padding: 0 1rem;
   }
+
+  .mypage__line {
+    width: calc(100% - 2.5rem);
+    height: 0.03125rem;
+
+    background-color: #f0f0f0;
+  }
 `;
 
 const ProfileBox = styled.div`
@@ -100,10 +107,6 @@ const LinkMenu = styled(Link)`
   text-decoration: none;
 
   cursor: pointer;
-
-  &:not(:first-child) {
-    border-top: 0.03125rem solid #f0f0f0;
-  }
 
   span {
     font-family: 'Apple SD Gothic Neo';
@@ -198,6 +201,7 @@ const MyPage = () => {
               />
             </svg>
           </LinkMenu>
+          <div className="mypage__line" />
           <LinkMenu to={`/mypage/account`}>
             <span>계정 설정</span>
             <svg


### PR DESCRIPTION
## 📟 연결된 이슈
close #17 

## 👷 작업한 내용
- 백엔드에서 변경한 프로필 수정 API(`/api/user`)에 대응해 Body를 수정했고, 프로필 사진을 변경하는 경우와 변경하지 않는 경우 둘 다에 대해서 요청이 성공적으로 이루어지는 것을 확인했습니다.
- 탭 바가 표시되지 않아도 되는 하위 페이지에 대해 디자인 변경 사항을 대응해 수정했습니다.
- 회원 탈퇴 모달을 `@components/account/WithdrawModal`로 분리해서 구현했고, 회원 탈퇴 API를 연결했습니다.
- 아이디 검색 허용 토글을 내부 상태 관리로만 구현했습니다.

## 🚨 참고 사항
- 실제 회원 탈퇴가 이루어지고 재가입 시 첫 가입 회원에 대해 프로필 수정 페이지가 표시되는 플로우는 별도로 테스트하지 않았습니다.

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|마이페이지|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/b614c48d-a919-46ae-8898-f4a4f6de680b" height="600px" />|
|계정 설정|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/674d6d11-4d59-4a80-bbbd-5f6f0fdc91ff" height="600px" />|
|회원 탈퇴 모달|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/d99a769c-d2a1-4810-9778-772a74ad34da" height="600px" />|