### PR TITLE
알림 페이지 기능 구현

### DIFF
--- a/src/components/notification/FriendAccepted.jsx
+++ b/src/components/notification/FriendAccepted.jsx
@@ -20,7 +20,7 @@ const ProfileImage = styled.img`
   background-color: green;
 `;
 
-const Content = styled.p`
+const Content = styled.div`
   flex-grow: 1;
 
   .row {
@@ -60,7 +60,7 @@ const Content = styled.p`
 const FriendAccepted = ({ profileName, profileImageUrl, time }) => {
   return (
     <Layout>
-      {profileImageUrl !== false ? (
+      {profileImageUrl ? (
         <ProfileImage src={profileImageUrl} />
       ) : (
         <ProfileImage />

--- a/src/components/notification/FriendReaction.jsx
+++ b/src/components/notification/FriendReaction.jsx
@@ -20,7 +20,7 @@ const ProfileImage = styled.img`
   background-color: green;
 `;
 
-const Content = styled.p`
+const Content = styled.div`
   flex-grow: 1;
 
   .row {
@@ -60,7 +60,7 @@ const Content = styled.p`
 const FriendReaction = ({ profileName, profileImageUrl, time }) => {
   return (
     <Layout>
-      {profileImageUrl !== false ? (
+      {profileImageUrl ? (
         <ProfileImage src={profileImageUrl} />
       ) : (
         <ProfileImage />

--- a/src/components/notification/FriendRequest.jsx
+++ b/src/components/notification/FriendRequest.jsx
@@ -21,7 +21,7 @@ const ProfileImage = styled.img`
   background-color: green;
 `;
 
-const Content = styled.p`
+const Content = styled.div`
   flex-grow: 1;
 
   .notification__name {
@@ -148,7 +148,7 @@ const FriendRequest = ({ accountId, profileName, profileImageUrl, time }) => {
 
   return (
     <Layout>
-      {profileImageUrl !== false ? (
+      {profileImageUrl ? (
         <ProfileImage src={profileImageUrl} />
       ) : (
         <ProfileImage />

--- a/src/components/notification/FriendRequest.jsx
+++ b/src/components/notification/FriendRequest.jsx
@@ -106,32 +106,27 @@ const FriendRequest = ({
 }) => {
   const handleFriendRequest = async (action) => {
     const accessToken = localStorage.getItem('accessToken');
-    const requestBody = {
-      id: friendId,
-    };
 
     try {
       if (action === 'accept') {
-        await axios({
-          method: 'PUT',
-          url: `/api/friend/add/accept`,
-          data: requestBody,
-          headers: { Authorization: `Bearer ${accessToken}` },
-        }).then((res) => {
-          console.log(res);
-          navigate();
-        });
+        const acceptResponse = await axios.put(
+          `/api/friend/add/accept`,
+          {
+            id: friendId,
+          },
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }
+        );
       } else if (action === 'decline') {
-        await axios({
-          method: 'DELETE',
-          url: `/api/friend/add/decline`,
-          data: requestBody,
+        const declineResponse = await axios.delete(`/api/friend/add/decline`, {
+          data: {
+            id: friendId,
+          },
           headers: { Authorization: `Bearer ${accessToken}` },
-        }).then((res) => {
-          console.log(res);
-          navigate();
         });
       }
+      navigate();
     } catch (error) {
       console.error('Error handling friend request:', error);
     }

--- a/src/components/notification/FriendRequest.jsx
+++ b/src/components/notification/FriendRequest.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 
 const Layout = styled.div`
   width: 100%;
@@ -96,50 +97,40 @@ const Button = styled.div`
   }
 `;
 
-const FriendRequest = ({ accountId, profileName, profileImageUrl, time }) => {
-  const [friendshipAccepted, setFriendshipAccepted] = useState([]);
-
+const FriendRequest = ({
+  profileName,
+  profileImageUrl,
+  friendId,
+  navigate,
+  time,
+}) => {
   const handleFriendRequest = async (action) => {
     const accessToken = localStorage.getItem('accessToken');
-
-    try {
-      const size = 10;
-      const lastId = '';
-
-      const response = await axios.get(
-        `/api/notification?size=${size}&lastId=${lastId}`,
-        {
-          headers: { Authorization: `Bearer ${accessToken}` },
-        }
-      );
-
-      const friendshipAcceptedData = response.data.filter(
-        (notification) => notification.type === 'FRIENDSHIP_ACCEPTED'
-      );
-
-      setFriendshipAccepted(friendshipAcceptedData);
-    } catch (error) {
-      console.error('Error fetching friend requests:', error);
-    }
+    const requestBody = {
+      id: friendId,
+    };
 
     try {
       if (action === 'accept') {
-        await axios.put(
-          `/api/friend/add/accept`,
-
-          {
-            headers: { Authorization: `Bearer ${accessToken}` },
-          }
-        );
-        setFriendshipAccepted([...friendshipAccepted, {}]);
+        await axios({
+          method: 'PUT',
+          url: `/api/friend/add/accept`,
+          data: requestBody,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }).then((res) => {
+          console.log(res);
+          navigate();
+        });
       } else if (action === 'decline') {
-        await axios.delete(
-          `/api/friend/add/decline`,
-
-          {
-            headers: { Authorization: `Bearer ${accessToken}` },
-          }
-        );
+        await axios({
+          method: 'DELETE',
+          url: `/api/friend/add/decline`,
+          data: requestBody,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }).then((res) => {
+          console.log(res);
+          navigate();
+        });
       }
     } catch (error) {
       console.error('Error handling friend request:', error);
@@ -165,13 +156,17 @@ const FriendRequest = ({ accountId, profileName, profileImageUrl, time }) => {
       <ButtonContainer>
         <Button
           className="notification__button__approve"
-          onClick={() => handleFriendRequest('accept')}
+          onClick={() => {
+            handleFriendRequest('accept');
+          }}
         >
           <span>수락</span>
         </Button>
         <Button
           className="notification__button__decline"
-          onClick={() => handleFriendRequest('decline')}
+          onClick={() => {
+            handleFriendRequest('decline');
+          }}
         >
           <span>거절</span>
         </Button>

--- a/src/components/notification/SeasonalNotify.jsx
+++ b/src/components/notification/SeasonalNotify.jsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { TermsToKorean } from '@utils/seasoning/TermsToKorean';
+
 import logo from '@assets/components/topbar/logo.png';
 
 const Layout = styled.div`
@@ -21,7 +23,7 @@ const ProfileImage = styled.img`
   flex-shrink: 0;
 `;
 
-const Content = styled.p`
+const Content = styled.div`
   flex-grow: 1;
 
   .notification__name {
@@ -54,13 +56,13 @@ const Content = styled.p`
   }
 `;
 
-const SeasonalNotify = ({ seasonName, time }) => {
+const SeasonalNotify = ({ term, time }) => {
   return (
     <Layout>
       <ProfileImage src={logo} />
 
       <Content>
-        <span className="notification__name">{seasonName}</span>
+        <span className="notification__name">{TermsToKorean[term]}</span>
         <span className="notification__content">노트가 열렸습니다</span>
         <br />
         <span className="notification__time">{time}</span>

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { useLoaderData, useNavigate } from 'react-router-dom';
 
@@ -19,7 +18,6 @@ const Top = styled.div`
   align-items: center;
 
   background-color: #fff;
-  box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.2);
 
   h1 {
     margin: 0;
@@ -128,7 +126,7 @@ const NotificationPage = () => {
                   profileImageUrl={
                     JSON.parse(notification.message).profileImageUrl
                   }
-                  friendId={null}
+                  friendId={JSON.parse(notification.message).id}
                   navigate={navigate}
                   time={formatNotificationTime()}
                 />
@@ -159,12 +157,6 @@ const NotificationPage = () => {
               return undefined;
           }
         })}
-
-        <FriendRequest
-          profileName={`poodlepoodle`}
-          profileImageUrl={null}
-          time={formatNotificationTime()}
-        />
 
         {notifications.length > 0 ? <div className="line" /> : undefined}
       </NotificationContainer>

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -25,7 +25,6 @@ const Top = styled.div`
 
     color: #000;
     text-align: center;
-
     font-family: 'Apple SD Gothic Neo';
     font-size: 1.25rem;
     font-style: normal;
@@ -46,23 +45,37 @@ const NotificationContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.75rem 1.31rem;
+  padding: 1.38rem 1.31rem;
   row-gap: 1.38rem;
   overflow-y: scroll;
+`;
 
-  .line {
-    width: 100%;
-    height: 0.0625rem;
+const Line = styled.div`
+  width: 100%;
+  min-height: 0.0625rem;
 
-    background-color: #e3e3e3;
-  }
+  background-color: #e3e3e3;
 `;
 
 const NotificationPage = () => {
+  const navigate = useNavigate();
   const { response } = useLoaderData();
   const [notifications, setNotifications] = useState(response.data);
-  const navigate = useNavigate();
-  console.log(notifications);
+  const [friendRequests, setFriendRequests] = useState([]);
+  const [otherNotifications, setOtherNotifications] = useState([]);
+
+  useEffect(() => {
+    setFriendRequests(
+      notifications.filter(
+        (notification) => notification.type === `FRIENDSHIP_REQUEST`
+      )
+    );
+    setOtherNotifications(
+      notifications.filter(
+        (notification) => notification.type !== `FRIENDSHIP_REQUEST`
+      )
+    );
+  }, [notifications]);
 
   const formatNotificationTime = (timestamp) => {
     const currentTime = new Date();
@@ -108,26 +121,26 @@ const NotificationPage = () => {
       </Top>
 
       <NotificationContainer>
-        {notifications.map((notification) => {
+        {friendRequests.map((notification) => (
+          <FriendRequest
+            key={notification.id}
+            profileName={JSON.parse(notification.message).nickname}
+            profileImageUrl={JSON.parse(notification.message).profileImageUrl}
+            friendId={JSON.parse(notification.message).id}
+            navigate={navigate}
+            time={formatNotificationTime()}
+          />
+        ))}
+        {friendRequests.length > 0 && otherNotifications.length > 0 ? (
+          <Line />
+        ) : undefined}
+        {otherNotifications.map((notification) => {
           switch (notification.type) {
             case 'ARTICLE_OPEN':
               return (
                 <SeasonalNotify
                   key={notification.id}
                   seasonName={notification.message}
-                  time={formatNotificationTime()}
-                />
-              );
-            case 'FRIENDSHIP_REQUEST':
-              return (
-                <FriendRequest
-                  key={notification.id}
-                  profileName={JSON.parse(notification.message).nickname}
-                  profileImageUrl={
-                    JSON.parse(notification.message).profileImageUrl
-                  }
-                  friendId={JSON.parse(notification.message).id}
-                  navigate={navigate}
                   time={formatNotificationTime()}
                 />
               );
@@ -157,8 +170,6 @@ const NotificationPage = () => {
               return undefined;
           }
         })}
-
-        {notifications.length > 0 ? <div className="line" /> : undefined}
       </NotificationContainer>
     </>
   );

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -4,8 +4,6 @@ import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { useLoaderData } from 'react-router-dom';
 
-import { TermsToKorean } from '@utils/seasoning/TermsToKorean';
-
 import FriendRequest from '@components/notification/FriendRequest';
 import FriendReaction from '@components/notification/FriendReaction';
 import FriendAccepted from '@components/notification/FriendAccepted';
@@ -55,7 +53,7 @@ const NotificationContainer = styled.div`
   overflow-y: scroll;
 
   .line {
-    width: calc(100% - 2.26rem);
+    width: 100%;
     height: 0.0625rem;
 
     background-color: #e3e3e3;
@@ -63,21 +61,9 @@ const NotificationContainer = styled.div`
 `;
 
 const NotificationPage = () => {
-  const { notificationData } = useLoaderData();
-  const {
-    friendRequestsData,
-    friendshipAcceptedData,
-    friendReactionData,
-    seasonalNotifyData,
-  } = notificationData;
-  console.log(notificationData);
-
-  const [friendRequests, setFriendRequests] = useState(friendRequestsData);
-  const [friendshipsAccepted, setFriendshipsAccepted] = useState(
-    friendshipAcceptedData
-  );
-  const [friendReactions, setFriendReactions] = useState(friendReactionData);
-  const [seasonalNotifies, setSeasonalNotifies] = useState(seasonalNotifyData);
+  const { response } = useLoaderData();
+  const [notifications, setNotifications] = useState(response.data);
+  console.log(notifications);
 
   const formatNotificationTime = (timestamp) => {
     const currentTime = new Date();
@@ -123,45 +109,55 @@ const NotificationPage = () => {
       </Top>
 
       <NotificationContainer>
-        {friendRequests.map((req, idx) => (
-          <FriendRequest
-            key={idx}
-            profileName={JSON.parse(req.message).nickname}
-            profileImageUrl={JSON.parse(req.message).profileImageUrl}
-            time={formatNotificationTime(req.createdAt)}
-          />
-        ))}
-        {friendRequests.length > 0 ? <div className="line" /> : undefined}
+        {notifications.map((notification) => {
+          switch (notification.type) {
+            case 'ARTICLE_OPEN':
+              return (
+                <SeasonalNotify
+                  key={notification.id}
+                  seasonName={notification.message}
+                  time={formatNotificationTime()}
+                />
+              );
+            case 'FRIENDSHIP_REQUEST':
+              return (
+                <FriendRequest
+                  key={notification.id}
+                  profileName={JSON.parse(notification.message).nickname}
+                  profileImageUrl={
+                    JSON.parse(notification.message).profileImageUrl
+                  }
+                  time={formatNotificationTime()}
+                />
+              );
+            case 'ARTICLE_FEEDBACK':
+              return (
+                <FriendReaction
+                  key={notification.id}
+                  profileName={JSON.parse(notification.message).nickname}
+                  profileImageUrl={
+                    JSON.parse(notification.message).profileImageUrl
+                  }
+                  time={formatNotificationTime()}
+                />
+              );
+            case 'FRIENDSHIP_ACCEPTED':
+              return (
+                <FriendAccepted
+                  key={notification.id}
+                  profileName={JSON.parse(notification.message).nickname}
+                  profileImageUrl={
+                    JSON.parse(notification.message).profileImageUrl
+                  }
+                  time={formatNotificationTime()}
+                />
+              );
+            default:
+              return undefined;
+          }
+        })}
 
-        {friendshipsAccepted.map((noti, idx) => (
-          <FriendAccepted
-            key={idx}
-            profileName={JSON.parse(noti.message).nickname}
-            profileImageUrl={JSON.parse(noti.message).profileImageUrl}
-            time={formatNotificationTime(noti.createdAt)}
-          />
-        ))}
-
-        {friendReactions.map((noti, idx) => (
-          <FriendReaction
-            key={idx}
-            setFriendReactions={
-              JSON.parse(noti.message).nicknamfriendReactionDatae
-            }
-            profileImageUrl={
-              sJSON.parses(noti.message).profileImaseasonalNotifyDatal
-            }
-            time={formatNotificationTime(noti.createdAt)}
-          />
-        ))}
-
-        {/* {seasonalNotifies.map((noti, idx) => (
-          <SeasonalNotify
-            key={idx}
-            seasonName={TermsToKorean[JSON.parse(seasonalNotify[0].message)]}
-            time={formatNotificationTime()}
-          />
-        ))} */}
+        {notifications.length > 0 ? <div className="line" /> : undefined}
       </NotificationContainer>
     </>
   );

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 
 import FriendRequest from '@components/notification/FriendRequest';
 import FriendReaction from '@components/notification/FriendReaction';
@@ -63,6 +63,7 @@ const NotificationContainer = styled.div`
 const NotificationPage = () => {
   const { response } = useLoaderData();
   const [notifications, setNotifications] = useState(response.data);
+  const navigate = useNavigate();
   console.log(notifications);
 
   const formatNotificationTime = (timestamp) => {
@@ -127,6 +128,8 @@ const NotificationPage = () => {
                   profileImageUrl={
                     JSON.parse(notification.message).profileImageUrl
                   }
+                  friendId={null}
+                  navigate={navigate}
                   time={formatNotificationTime()}
                 />
               );
@@ -156,6 +159,12 @@ const NotificationPage = () => {
               return undefined;
           }
         })}
+
+        <FriendRequest
+          profileName={`poodlepoodle`}
+          profileImageUrl={null}
+          time={formatNotificationTime()}
+        />
 
         {notifications.length > 0 ? <div className="line" /> : undefined}
       </NotificationContainer>

--- a/src/utils/api/NotificationLoader.jsx
+++ b/src/utils/api/NotificationLoader.jsx
@@ -20,26 +20,7 @@ export const NotificationLoader = async ({ request, params }) => {
       }
     );
 
-    const friendRequestsData = response.data.filter(
-      (notification) => notification.type === 'FRIENDSHIP_REQUEST'
-    );
-    const friendshipAcceptedData = response.data.filter(
-      (notification) => notification.type === 'FRIENDSHIP_ACCEPTED'
-    );
-    const friendReactionData = response.data.filter(
-      (notification) => notification.type === 'ARTICLE_FEEDBACK'
-    );
-    const seasonalNotifyData = response.data.filter(
-      (notification) => notification.type === 'ARTICLE_OPEN'
-    );
-    const notificationData = {
-      friendRequestsData: friendRequestsData,
-      friendshipAcceptedData: friendshipAcceptedData,
-      friendReactionData: friendReactionData,
-      seasonalNotifyData: seasonalNotifyData,
-    };
-
-    return { notificationData };
+    return { response };
   } catch (error) {
     console.error(error);
     console.log('* Response Error... Redirecting to /login');


### PR DESCRIPTION
## 📟 연결된 이슈
close #18 

## 👷 작업한 내용
- API에서 요청한 각 알림 데이터의 유형 별로 매칭되는 알림 컴포넌트를 렌더링하도록 구현했습니다.
- 친구 수락 요청 알림에 대해서 수락 및 거절 API 요청을 구현하고, 테스트했습니다.
- 친구 수락 요청 알림과 나머지 알림 유형을 분리해서 관리하도록 방식을 수정했습니다.

## 🚨 참고 사항
- 친구 수락 알림은 `friendRequests`, 기타 모든 유형의 알림은 `otherNotifications`로 관리합니다.

## 📸 스크린샷
.
