### PR TITLE
홈 페이지 기능 구현

### DIFF
--- a/src/components/home/ArticleRow.jsx
+++ b/src/components/home/ArticleRow.jsx
@@ -1,15 +1,12 @@
 import styled from 'styled-components';
 
-import thumbs from '@assets/home/sample_thumbnail.png';
-
 const Container = styled.div`
   width: 100%;
   height: 5.88rem;
-  border-top: 0.03125rem solid #a9a9a9;
-  padding: 0 1.38rem;
+  padding: 0.75rem 1.38rem;
 
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   column-gap: 1rem;
 `;
 
@@ -17,29 +14,31 @@ const Thumbnail = styled.div`
   min-width: 4.375rem;
   max-width: 4.375rem;
   height: 4.375rem;
+  flex-shrink: 0;
+
   border-radius: 0.5rem;
   overflow: hidden;
 
   img {
     width: 100%;
     height: 100%;
+    object-fit: cover;
   }
 `;
 
 const Description = styled.p`
-  color: #333;
+  /* height: 100%; */
+  flex-grow: 1;
+  margin-top: 0.5rem;
 
-  font-family: AppleSDGothicNeo;
+  color: #333;
+  font-family: 'Apple SD Gothic Neo';
   font-size: 0.875rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
 
   text-overflow: ellipsis;
-
-  /* Needed to make it work */
-  /* overflow: hidden;
-  white-space: nowrap; */
 
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -52,14 +51,10 @@ const ArticleRow = (props) => {
     <Container>
       {props.thumbnail && (
         <Thumbnail>
-          <img src={thumbs} />
+          <img src={props.thumbnail} />
         </Thumbnail>
       )}
-      <Description>
-        봄은 자연에서 새로운 생명과 활기가 물씬 풍기는 아름다운 계절입니다.
-        새로운 잎이 나고 꽃들이 피어나며 새로운 생명이 시작되는 시기이죠. 봄은
-        이러한 자연의 신생을 상징하면서 새로운 생명과
-      </Description>
+      <Description>{props.text}</Description>
     </Container>
   );
 };

--- a/src/components/home/ArticleRow.jsx
+++ b/src/components/home/ArticleRow.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
-const Container = styled.div`
+const Container = styled(Link)`
   width: 100%;
   height: 5.88rem;
   padding: 0.75rem 1.38rem;
@@ -48,7 +49,7 @@ const Description = styled.p`
 
 const ArticleRow = (props) => {
   return (
-    <Container>
+    <Container to={`/article/${props.articleId}`}>
       {props.thumbnail && (
         <Thumbnail>
           <img src={props.thumbnail} />

--- a/src/components/home/SeasonCircle.jsx
+++ b/src/components/home/SeasonCircle.jsx
@@ -165,11 +165,9 @@ const SeasonCircle = (props) => {
     const Timer = setInterval(() => {
       setNow(new Date());
     }, 1000);
-    console.log('mount!');
 
     return () => {
       clearInterval(Timer);
-      console.log('unmount!');
     };
   }, []);
 

--- a/src/components/home/SeasonMenu.jsx
+++ b/src/components/home/SeasonMenu.jsx
@@ -75,9 +75,9 @@ const Square = styled.div`
   background-color: #333;
 `;
 
-const SeasonMenu = ({ term }) => {
+const SeasonMenu = ({ term, onClick }) => {
   return (
-    <Container>
+    <Container onClick={onClick}>
       <Square>
         <span className="season__menu__chinese">{TermsToChinese[term]}</span>
       </Square>

--- a/src/components/home/SeasonalContent.jsx
+++ b/src/components/home/SeasonalContent.jsx
@@ -1,50 +1,141 @@
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 
 import SeasonMenu from '@components/home/SeasonMenu';
 import ArticleRow from '@components/home/ArticleRow';
 
 const Container = styled.section`
+  position: relative;
+  /* width: 100%; */
   /* height: 100%; */
 
   display: flex;
   flex-direction: column;
+  align-items: center;
+
+  background-color: yellow;
 `;
 
 const Menus = styled.section`
+  position: relative;
   height: 7.31rem;
+
   display: flex;
   align-items: flex-start;
   padding: 0 1.31rem;
   gap: 1.13rem;
-  overflow-y: hidden;
+  overflow-x: scroll;
+  /* overflow-y: hidden; */
 `;
 
 const Content = styled.section`
-  background-color: #ffffff;
+  position: relative;
+  width: 100%;
+  height: calc(100% - 7.31rem);
+
+  /* display: flex;
+  flex-direction: column;
+  align-items: center; */
+`;
+
+const Line = styled.div`
+  width: calc(100% - 1.25rem);
+  height: 0.03125rem;
+  background-color: #a9a9a9;
 `;
 
 const SeasonalContent = () => {
   const terms = Array.from({ length: 24 }, (_, i) => i + 1);
+  const [selectedTerm, setSelectedTerm] = useState(1);
+  const [articles, setArticles] = useState([]);
+
+  console.log(articles);
+
+  useEffect(() => {
+    console.log(`${selectedTerm}번 절기에 대한 글을 불러옵니다...`);
+
+    const fetchArticlesByTerm = async () => {
+      const accessToken = localStorage.getItem('accessToken');
+
+      await axios({
+        method: 'GET',
+        url: `/api/article/list/term/${selectedTerm}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }).then((res) => {
+        setArticles(res.data);
+      });
+    };
+    fetchArticlesByTerm();
+  }, [selectedTerm]);
 
   return (
-    <>
-      <Container>
-        <Menus>
-          {terms.map((term) => (
-            <SeasonMenu key={term} term={term} />
-          ))}
-        </Menus>
+    <Container>
+      <Menus>
+        {terms.map((term) => (
+          <SeasonMenu
+            key={term}
+            term={term}
+            onClick={() => setSelectedTerm(term)}
+          />
+        ))}
+      </Menus>
 
-        <Content>
-          <ArticleRow thumbnail />
-          <ArticleRow thumbnail />
-          <ArticleRow />
-          <ArticleRow thumbnail />
-          <ArticleRow thumbnail />
-          <ArticleRow thumbnail />
-        </Content>
-      </Container>
-    </>
+      <Content>
+        {/* {articles.length >= 0 ? <Line /> : undefined}
+        {articles.map((article, idx) => (
+          <React.Fragment key={idx}>
+            <ArticleRow thumbnail={article.image} text={article.preview} />
+            <Line />
+          </React.Fragment>
+        ))}
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={'테스트 테스트 테스트 테스트'}
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={'테스트 테스트 테스트 테스트'}
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={
+            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
+          }
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={
+            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
+          }
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={
+            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
+          }
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={
+            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
+          }
+        />
+        <Line />
+        <ArticleRow
+          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
+          text={
+            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
+          }
+        />
+        <Line /> */}
+      </Content>
+    </Container>
   );
 };
 

--- a/src/components/home/SeasonalContent.jsx
+++ b/src/components/home/SeasonalContent.jsx
@@ -83,10 +83,14 @@ const SeasonalContent = () => {
       </Menus>
 
       <Content>
-        {articles.map((article, idx) => (
-          <React.Fragment key={idx}>
+        {articles.map((article) => (
+          <React.Fragment key={article.id}>
             <Line />
-            <ArticleRow thumbnail={article.image} text={article.preview} />
+            <ArticleRow
+              articleId={article.id}
+              thumbnail={article.image}
+              text={article.preview}
+            />
           </React.Fragment>
         ))}
       </Content>

--- a/src/components/home/SeasonalContent.jsx
+++ b/src/components/home/SeasonalContent.jsx
@@ -7,18 +7,17 @@ import ArticleRow from '@components/home/ArticleRow';
 
 const Container = styled.section`
   position: relative;
-  /* width: 100%; */
-  /* height: 100%; */
+  width: 100%;
+  height: 100%;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  background-color: yellow;
 `;
 
 const Menus = styled.section`
   position: relative;
+  width: 100%;
   height: 7.31rem;
 
   display: flex;
@@ -26,7 +25,7 @@ const Menus = styled.section`
   padding: 0 1.31rem;
   gap: 1.13rem;
   overflow-x: scroll;
-  /* overflow-y: hidden; */
+  overflow-y: hidden;
 `;
 
 const Content = styled.section`
@@ -34,14 +33,16 @@ const Content = styled.section`
   width: 100%;
   height: calc(100% - 7.31rem);
 
-  /* display: flex;
+  display: flex;
   flex-direction: column;
-  align-items: center; */
+  align-items: center;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 const Line = styled.div`
   width: calc(100% - 1.25rem);
-  height: 0.03125rem;
+  min-height: 0.03125rem;
   background-color: #a9a9a9;
 `;
 
@@ -53,7 +54,7 @@ const SeasonalContent = () => {
   console.log(articles);
 
   useEffect(() => {
-    console.log(`${selectedTerm}번 절기에 대한 글을 불러옵니다...`);
+    console.log(`${selectedTerm}번 절기에 대한 글을 불러옵니다.`);
 
     const fetchArticlesByTerm = async () => {
       const accessToken = localStorage.getItem('accessToken');
@@ -82,58 +83,12 @@ const SeasonalContent = () => {
       </Menus>
 
       <Content>
-        {/* {articles.length >= 0 ? <Line /> : undefined}
         {articles.map((article, idx) => (
           <React.Fragment key={idx}>
-            <ArticleRow thumbnail={article.image} text={article.preview} />
             <Line />
+            <ArticleRow thumbnail={article.image} text={article.preview} />
           </React.Fragment>
         ))}
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={'테스트 테스트 테스트 테스트'}
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={'테스트 테스트 테스트 테스트'}
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={
-            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
-          }
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={
-            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
-          }
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={
-            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
-          }
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={
-            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
-          }
-        />
-        <Line />
-        <ArticleRow
-          thumbnail={`https://image.fmkorea.com/files/attach/new3/20240208/486616/6334843684/6702009047/5ffffb04008e296e138671ef25ff09bf.png`}
-          text={
-            '테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트 테스트'
-          }
-        />
-        <Line /> */}
       </Content>
     </Container>
   );

--- a/src/components/home/YearlyContent.jsx
+++ b/src/components/home/YearlyContent.jsx
@@ -4,11 +4,15 @@ import SeasonCircle from '@components/home/SeasonCircle';
 
 import yearly_line from '@assets/home/yearly_line.png';
 
-const Container = styled.section`
+const Layout = styled.section`
+  position: relative;
+
   display: flex;
   flex-direction: column;
   row-gap: 1.6rem;
   margin-top: 0.5rem;
+  padding: 1rem 0;
+  overflow-y: auto;
 
   background-image: url(${yearly_line});
   background-size: cover;
@@ -37,54 +41,52 @@ const LastRow = styled.div`
 
 const YearlyContent = ({ now, termData }) => {
   return (
-    <>
-      <Container>
-        <FirstRow>
-          <SeasonCircle now={now} term={1} termData={termData} />
-          <SeasonCircle now={now} term={2} termData={termData} />
-          <SeasonCircle now={now} term={3} termData={termData} />
-        </FirstRow>
-        <Row>
-          <SeasonCircle now={now} term={5} termData={termData} />
-          <SeasonCircle now={now} term={4} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={6} termData={termData} />
-          <SeasonCircle now={now} term={7} termData={termData} />
-          <SeasonCircle now={now} term={8} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={10} termData={termData} />
-          <SeasonCircle now={now} term={9} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={11} termData={termData} />
-          <SeasonCircle now={now} term={12} termData={termData} />
-          <SeasonCircle now={now} term={13} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={15} termData={termData} />
-          <SeasonCircle now={now} term={14} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={16} termData={termData} />
-          <SeasonCircle now={now} term={17} termData={termData} />
-          <SeasonCircle now={now} term={18} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={20} termData={termData} />
-          <SeasonCircle now={now} term={19} termData={termData} />
-        </Row>
-        <Row>
-          <SeasonCircle now={now} term={21} termData={termData} />
-          <SeasonCircle now={now} term={22} termData={termData} />
-          <SeasonCircle now={now} term={23} termData={termData} />
-        </Row>
-        <LastRow>
-          <SeasonCircle now={now} term={24} termData={termData} />
-        </LastRow>
-      </Container>
-    </>
+    <Layout>
+      <FirstRow>
+        <SeasonCircle now={now} term={1} termData={termData} />
+        <SeasonCircle now={now} term={2} termData={termData} />
+        <SeasonCircle now={now} term={3} termData={termData} />
+      </FirstRow>
+      <Row>
+        <SeasonCircle now={now} term={5} termData={termData} />
+        <SeasonCircle now={now} term={4} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={6} termData={termData} />
+        <SeasonCircle now={now} term={7} termData={termData} />
+        <SeasonCircle now={now} term={8} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={10} termData={termData} />
+        <SeasonCircle now={now} term={9} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={11} termData={termData} />
+        <SeasonCircle now={now} term={12} termData={termData} />
+        <SeasonCircle now={now} term={13} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={15} termData={termData} />
+        <SeasonCircle now={now} term={14} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={16} termData={termData} />
+        <SeasonCircle now={now} term={17} termData={termData} />
+        <SeasonCircle now={now} term={18} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={20} termData={termData} />
+        <SeasonCircle now={now} term={19} termData={termData} />
+      </Row>
+      <Row>
+        <SeasonCircle now={now} term={21} termData={termData} />
+        <SeasonCircle now={now} term={22} termData={termData} />
+        <SeasonCircle now={now} term={23} termData={termData} />
+      </Row>
+      <LastRow>
+        <SeasonCircle now={now} term={24} termData={termData} />
+      </LastRow>
+    </Layout>
   );
 };
 

--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -212,7 +212,7 @@ const ContentArea = styled.div`
   overflow-y: auto;
 
   width: 100%;
-  height: calc(100% - 3.5rem - 3.5625rem - 2.95rem - 4.4375rem);
+  height: calc(100% - 2.5rem - 3.5625rem - 2.95rem - 4.4375rem);
   padding-bottom: 3.8125rem;
 
   /* background-color: yellow; */

--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -214,6 +214,8 @@ const ContentArea = styled.div`
   width: 100%;
   height: calc(100% - 3.5rem - 3.5625rem - 2.95rem - 4.4375rem);
   padding-bottom: 3.8125rem;
+
+  /* background-color: yellow; */
 `;
 
 const HomePage = () => {


### PR DESCRIPTION
## 📟 연결된 이슈
close #12 

## 👷 작업한 내용
- **연도 별 보기**의 컴포넌트들을 상태에 따라 렌더링하는 부분을 수정했습니다.
- **절기 별 보기**의 각 절기 요소 선택에 따른 글 목록을 렌더링하고, 각 글을 클릭했을 시 해당 글 조회 페이지로 연결하도록 구현했습니다.

## 🚨 참고 사항
- 아직 구현하지 못한 내용입니다.
  - [ ] 백엔드에서 요청한 `/solarTerm` API 값에 따라 활성화되는 절기를 상호 검증 후 적용합니다.
  - [ ] **연도 별 보기**의 초 단위 카운트다운에 의해 발생하는 `background-image` 버그를 수정합니다.
  - [ ] 읽지 않은 새로운 알림이 와 있는 경우 알림 아이콘을 다르게 표시합니다.

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|연도 별 보기|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/ca5132ee-dd68-4597-8df2-e057f4bd66d6" height="600px" />|
|절기 별 보기|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/7645bb45-09cd-45d6-8bf6-91e6a2ce3125" height="600px" />|