### PR TITLE
피드 페이지 기능 구현

### DIFF
--- a/src/components/feed/FeedItem.jsx
+++ b/src/components/feed/FeedItem.jsx
@@ -108,9 +108,11 @@ const FeedItem = (props) => {
         </section>
       </ProfileContainer>
 
-      <ThumbnailImage>
-        <img src={article.image} />
-      </ThumbnailImage>
+      {article.image ? (
+        <ThumbnailImage>
+          <img src={article.image} />
+        </ThumbnailImage>
+      ) : undefined}
 
       <Content>{article.preview}</Content>
     </ContentLayout>

--- a/src/components/feed/FeedItem.jsx
+++ b/src/components/feed/FeedItem.jsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 import UserProfileBox from '@components/common/UserProfileBox';
+import { TermsToChinese } from '@utils/seasoning/TermsToChinese';
+import { TermsToKorean } from '@utils/seasoning/TermsToKorean';
 
-const ContentLayout = styled.div`
+const ContentLayout = styled(Link)`
   position: relative;
   width: 100%;
 
@@ -85,30 +88,32 @@ const Content = styled.div`
 `;
 
 const FeedItem = (props) => {
-  const data = props.data;
+  const { profile, article } = props.data;
 
   return (
-    <>
-      <ContentLayout>
-        <ProfileContainer>
-          <UserProfileBox
-            profileImage={data.profile.image}
-            nickname={data.profile.nickname}
-            accountId={data.profile.accountID}
-          />
-          <section className="profile__season">
-            <span className="profile__season__korean">입춘</span>
-            <span className="profile__season__chinese">立春</span>
-          </section>
-        </ProfileContainer>
+    <ContentLayout to={`/article/${article.id}`}>
+      <ProfileContainer>
+        <UserProfileBox
+          profileImage={profile.image}
+          nickname={profile.nickname}
+          accountId={profile.accountID}
+        />
+        <section className="profile__season">
+          <span className="profile__season__korean">
+            {TermsToKorean[article.term]}
+          </span>
+          <span className="profile__season__chinese">
+            {TermsToChinese[article.term]}
+          </span>
+        </section>
+      </ProfileContainer>
 
-        <ThumbnailImage>
-          <img src={data.article.image} />
-        </ThumbnailImage>
+      <ThumbnailImage>
+        <img src={article.image} />
+      </ThumbnailImage>
 
-        <Content>{data.article.preview}</Content>
-      </ContentLayout>
-    </>
+      <Content>{article.preview}</Content>
+    </ContentLayout>
   );
 };
 

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -17,7 +17,6 @@ const Top = styled.div`
   padding: 0 1.31rem;
 
   background-color: #fff;
-  box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.2);
 
   h1 {
     margin: 0;

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useLoaderData, useNavigate, useLocation } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 
 import FeedItem from '@components/feed/FeedItem';
 import TabBar from '@components/common/TabBar';
@@ -47,7 +47,6 @@ const ContentArea = styled.div`
 const FeedPage = () => {
   const { response } = useLoaderData();
   const [feedData, setFeedData] = useState(response.data);
-
   console.log(feedData);
 
   return (

--- a/src/pages/feed/FriendsListPage.jsx
+++ b/src/pages/feed/FriendsListPage.jsx
@@ -15,7 +15,6 @@ const Top = styled.div`
   align-items: center;
 
   background-color: #fff;
-  box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.2);
 
   h1 {
     margin: 0;


### PR DESCRIPTION
## 📟 연결된 이슈
close #13 

## 👷 작업한 내용
- 친구 피드의 각 아이템 클릭 시 대응되는 친구 기록장 보기 페이지로 연결하도록 구현했습니다.
- 친구 피드 게시물 중, 이미지가 포함되지 않은 요소에 대해 조건부 렌더링을 수행하도록 수정했습니다.

## 🚨 참고 사항
- 친구 피드 게시물이 없는 관계로 테스트는 해 보지 못했습니다.

## 📸 스크린샷
.
