### PR TITLE
모달 재사용성 고려 리팩토링

### DIFF
--- a/src/components/account/WithdrawModal.jsx
+++ b/src/components/account/WithdrawModal.jsx
@@ -2,18 +2,7 @@ import styled from 'styled-components';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
-const ModalBackground = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  z-index: 2000;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
+import withModalBackground from '@components/hoc/withModalBackground';
 
 const ModalOverlay = styled.div`
   position: relative;
@@ -74,7 +63,7 @@ const Button = styled.div`
   }
 `;
 
-const WithdrawModal = ({ setShowModal }) => {
+const WithdrawModal = ({ onCloseModal }) => {
   const navigate = useNavigate();
 
   const handleWithdraw = async () => {
@@ -93,20 +82,18 @@ const WithdrawModal = ({ setShowModal }) => {
   };
 
   return (
-    <ModalBackground>
-      <ModalOverlay>
-        <Title>정말로 회원 탈퇴 하시겠습니까?</Title>
-        <ButtonContainer>
-          <Button warning onClick={handleWithdraw}>
-            <span>탈퇴하기</span>
-          </Button>
-          <Button onClick={() => setShowModal(false)}>
-            <span>취소</span>
-          </Button>
-        </ButtonContainer>
-      </ModalOverlay>
-    </ModalBackground>
+    <ModalOverlay>
+      <Title>정말로 회원 탈퇴 하시겠습니까?</Title>
+      <ButtonContainer>
+        <Button warning onClick={handleWithdraw}>
+          <span>탈퇴하기</span>
+        </Button>
+        <Button onClick={onCloseModal}>
+          <span>취소</span>
+        </Button>
+      </ButtonContainer>
+    </ModalOverlay>
   );
 };
 
-export default WithdrawModal;
+export default withModalBackground(WithdrawModal);

--- a/src/components/hoc/withModalBackground.jsx
+++ b/src/components/hoc/withModalBackground.jsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+const ModalBackground = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1001;
+`;
+
+const withModalBackground = (WrappedModal) => {
+  return (props) => {
+    const handleBackgroundClick = (event) => {
+      if (event.target === event.currentTarget) {
+        props.onCloseModal();
+      }
+    };
+
+    return (
+      <ModalBackground onClick={handleBackgroundClick}>
+        <WrappedModal {...props} />
+      </ModalBackground>
+    );
+  };
+};
+
+export default withModalBackground;

--- a/src/components/hoc/withModalBackground.jsx
+++ b/src/components/hoc/withModalBackground.jsx
@@ -1,4 +1,13 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
 
 const ModalBackground = styled.div`
   position: absolute;
@@ -10,6 +19,7 @@ const ModalBackground = styled.div`
   align-items: center;
 
   background-color: rgba(0, 0, 0, 0.5);
+  animation: ${fadeIn} 0.3s ease-out;
   z-index: 1001;
 `;
 

--- a/src/components/home/FortuneModal.jsx
+++ b/src/components/home/FortuneModal.jsx
@@ -1,17 +1,6 @@
 import styled from 'styled-components';
 
-const ModalBackground = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  z-index: 2000;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
+import withModalBackground from '@components/hoc/withModalBackground';
 
 const ModalOverlay = styled.div`
   position: relative;
@@ -89,34 +78,30 @@ const ModalContent = styled.div`
   line-height: normal;
 `;
 
-const FortuneModal = ({ now, setShowModal, fortuneText }) => {
+const FortuneModal = ({ now, fortuneText, onCloseModal }) => {
   return (
-    <ModalBackground>
-      <ModalOverlay>
-        <ModalTop>
-          <span>{`${now.getMonth() + 1}월 ${now.getDate()}일`}</span>
-          <svg
-            onClick={() => {
-              setShowModal(false);
-            }}
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <path
-              d="M6.40002 18.6538L5.34619 17.6L10.9462 12L5.34619 6.40002L6.40002 5.34619L12 10.9462L17.6 5.34619L18.6538 6.40002L13.0538 12L18.6538 17.6L17.6 18.6538L12 13.0538L6.40002 18.6538Z"
-              fill="black"
-            />
-          </svg>
-        </ModalTop>
-        <ModalTitle>오늘의 운세</ModalTitle>
-        <Hr />
-        <ModalContent>{fortuneText}</ModalContent>
-      </ModalOverlay>
-    </ModalBackground>
+    <ModalOverlay>
+      <ModalTop>
+        <span>{`${now.getMonth() + 1}월 ${now.getDate()}일`}</span>
+        <svg
+          onClick={onCloseModal}
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <path
+            d="M6.40002 18.6538L5.34619 17.6L10.9462 12L5.34619 6.40002L6.40002 5.34619L12 10.9462L17.6 5.34619L18.6538 6.40002L13.0538 12L18.6538 17.6L17.6 18.6538L12 13.0538L6.40002 18.6538Z"
+            fill="black"
+          />
+        </svg>
+      </ModalTop>
+      <ModalTitle>오늘의 운세</ModalTitle>
+      <Hr />
+      <ModalContent>{fortuneText}</ModalContent>
+    </ModalOverlay>
   );
 };
 
-export default FortuneModal;
+export default withModalBackground(FortuneModal);

--- a/src/components/write/ArticleDeleteModal.jsx
+++ b/src/components/write/ArticleDeleteModal.jsx
@@ -2,18 +2,7 @@ import styled from 'styled-components';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
-const ModalBackground = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  z-index: 2000;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
+import withModalBackground from '@components/hoc/withModalBackground';
 
 const ModalOverlay = styled.div`
   position: relative;
@@ -74,21 +63,17 @@ const Button = styled.div`
   }
 `;
 
-const ArticleDeleteModal = ({
-  articleId,
-  setShowMenuModal,
-  setShowDeleteModal,
-}) => {
+const ArticleDeleteModal = ({ articleId, onCloseModal }) => {
   const navigate = useNavigate();
 
   const handleDelete = async () => {
     const accessToken = localStorage.getItem('accessToken');
-    console.log(articleId);
 
     try {
       const response = await axios.delete(`/api/article/${articleId}`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
+
       navigate(`/home`);
     } catch (error) {
       console.error('Error trying delete article:', error);
@@ -96,25 +81,18 @@ const ArticleDeleteModal = ({
   };
 
   return (
-    <ModalBackground>
-      <ModalOverlay>
-        <Title>삭제한 기록장은 복구되지 않습니다.</Title>
-        <ButtonContainer>
-          <Button warning onClick={handleDelete}>
-            <span>삭제하기</span>
-          </Button>
-          <Button
-            onClick={() => {
-              setShowMenuModal(false);
-              setShowDeleteModal(false);
-            }}
-          >
-            <span>취소</span>
-          </Button>
-        </ButtonContainer>
-      </ModalOverlay>
-    </ModalBackground>
+    <ModalOverlay>
+      <Title>삭제한 기록장은 복구되지 않습니다.</Title>
+      <ButtonContainer>
+        <Button warning onClick={handleDelete}>
+          <span>삭제하기</span>
+        </Button>
+        <Button onClick={onCloseModal}>
+          <span>취소</span>
+        </Button>
+      </ButtonContainer>
+    </ModalOverlay>
   );
 };
 
-export default ArticleDeleteModal;
+export default withModalBackground(ArticleDeleteModal);

--- a/src/components/write/ArticleMenuModal.jsx
+++ b/src/components/write/ArticleMenuModal.jsx
@@ -2,18 +2,7 @@ import styled, { keyframes } from 'styled-components';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
-const ModalBackground = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  z-index: 10;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
+import withModalBackground from '@components/hoc/withModalBackground';
 
 const slideUp = keyframes`
   from {
@@ -30,7 +19,7 @@ const ModalOverlay = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
-  /* height: 8rem; */
+  height: 8rem;
   flex-shrink: 0;
   z-index: 1000;
 
@@ -70,29 +59,26 @@ const ModalContent = styled.div`
   }
 `;
 
-const ArticleMenuModal = ({ setShowMenuModal, setShowDeleteModal }) => {
-  const onCloseModal = () => {
-    setShowMenuModal(false);
-  };
-  const handleArticleEdit = () => {
-    setShowMenuModal(false);
-  };
+const ArticleMenuModal = ({ onCloseModal, setShowDeleteModal }) => {
   const handleArticleDelete = () => {
+    onCloseModal();
     setShowDeleteModal(true);
   };
 
   return (
-    <ModalBackground>
-      <ModalOverlay>
-        <ModalContent onClick={handleArticleEdit}>
-          <span>수정하기</span>
-        </ModalContent>
-        <ModalContent warning onClick={handleArticleDelete}>
-          <span>삭제하기</span>
-        </ModalContent>
-      </ModalOverlay>
-    </ModalBackground>
+    <ModalOverlay>
+      <ModalContent
+        onClick={() => {
+          alert('수정하기 구현 중...');
+        }}
+      >
+        <span>수정하기</span>
+      </ModalContent>
+      <ModalContent warning onClick={handleArticleDelete}>
+        <span>삭제하기</span>
+      </ModalContent>
+    </ModalOverlay>
   );
 };
 
-export default ArticleMenuModal;
+export default withModalBackground(ArticleMenuModal);

--- a/src/components/write/ArticleMenuModal.jsx
+++ b/src/components/write/ArticleMenuModal.jsx
@@ -7,11 +7,9 @@ import withModalBackground from '@components/hoc/withModalBackground';
 const slideUp = keyframes`
   from {
     transform: translateY(100%);
-    opacity: 0;
   }
   to {
     transform: translateY(0);
-    opacity: 1;
   }
 `;
 

--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -12,6 +12,12 @@ import TabBar from '@components/common/TabBar';
 import { TermsToChinese } from '@utils/seasoning/TermsToChinese';
 import { TermsToKorean } from '@utils/seasoning/TermsToKorean';
 
+const Layout = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
 const Season = styled.div`
   position: relative;
   width: 100%;
@@ -107,12 +113,6 @@ const Fortune = styled.div`
     font-weight: 400;
     line-height: normal;
   }
-`;
-
-const PopupLayout = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: center;
 `;
 
 const Category = styled.div`
@@ -234,16 +234,16 @@ const HomePage = () => {
   };
 
   return (
-    <>
-      <PopupLayout>
-        {showModal && (
-          <FortuneModal
-            now={now}
-            setShowModal={setShowModal}
-            fortuneText={fortuneText}
-          />
-        )}
-      </PopupLayout>
+    <Layout>
+      {showModal && (
+        <FortuneModal
+          now={now}
+          fortuneText={fortuneText}
+          onCloseModal={() => {
+            setShowModal(false);
+          }}
+        />
+      )}
 
       <TopBar />
 
@@ -333,7 +333,7 @@ const HomePage = () => {
       </ContentArea>
 
       <TabBar />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/mypage/AccountPage.jsx
+++ b/src/pages/mypage/AccountPage.jsx
@@ -119,9 +119,13 @@ const AccountPage = () => {
 
   return (
     <Layout>
-      <PopupLayout>
-        {showModal && <WithdrawModal setShowModal={setShowModal} />}
-      </PopupLayout>
+      {showModal && (
+        <WithdrawModal
+          onCloseModal={() => {
+            setShowModal(false);
+          }}
+        />
+      )}
 
       <Top>
         <h1>계정 설정</h1>

--- a/src/pages/write/ArticlePage.jsx
+++ b/src/pages/write/ArticlePage.jsx
@@ -219,63 +219,6 @@ const EmojiButton = styled.div`
   }
 `;
 
-const PopupLayout = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: center;
-`;
-
-/* 삭제 팝업창 */
-/* const DeleteModalOverlay = styled.div`
-  position: absolute;
-  top: 15rem;
-  width: 17.6875rem;
-  height: 12.5rem;
-  z-index: 1000;
-
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  border-radius: 1.25rem;
-  background: #fff;
-  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.25);
-`;
-
-const DeleteModalContent = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-
-  width: 100%;
-  color: #000;
-  text-align: center;
-  font-family: 'Apple SD Gothic Neo';
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 600;
-  line-height: normal;
-
-  img {
-    width: 6rem;
-    height: 5rem;
-  }
-`;
-
-const DeleteButton = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-
-  span {
-    cursor: pointer;
-  }
-`; */
-
 const ArticlePage = () => {
   const { articleId, response } = useLoaderData();
   const articleData = response.data;
@@ -357,21 +300,23 @@ const ArticlePage = () => {
 
   return (
     <Layout>
-      <PopupLayout>
-        {showMenuModal && (
-          <ArticleMenuModal
-            setShowMenuModal={setShowMenuModal}
-            setShowDeleteModal={setShowDeleteModal}
-          />
-        )}
-        {showDeleteModal && (
-          <ArticleDeleteModal
-            articleId={articleId}
-            setShowMenuModal={setShowMenuModal}
-            setShowDeleteModal={setShowDeleteModal}
-          />
-        )}
-      </PopupLayout>
+      {showMenuModal && (
+        <ArticleMenuModal
+          onCloseModal={() => {
+            setShowMenuModal(false);
+          }}
+          setShowDeleteModal={setShowDeleteModal}
+        />
+      )}
+      {showDeleteModal && (
+        <ArticleDeleteModal
+          articleId={articleId}
+          onCloseModal={() => {
+            setShowMenuModal(false);
+            setShowDeleteModal(false);
+          }}
+        />
+      )}
 
       <Top>
         <Link to={`/home`}>
@@ -489,23 +434,6 @@ const ArticlePage = () => {
         </EmojiButton>
         <span>{articleData.published ? '' : '비공개'}</span>
       </Bottom>
-
-      {/* {showDeleteModal && (
-        <DeleteModalOverlay>
-          <DeleteModalContent>
-            <img src={injulgi} />
-            인절기에게 먹힌 기록장은
-            <br />
-            복구할 수 없어요
-            <DeleteButton>
-              <span onClick={RealDelete} style={{ color: 'red' }}>
-                삭제
-              </span>
-              <span onClick={CancelDelete}>취소</span>
-            </DeleteButton>
-          </DeleteModalContent>
-        </DeleteModalOverlay>
-      )} */}
     </Layout>
   );
 };


### PR DESCRIPTION
## 📟 연결된 이슈
close #28 

## 👷 작업한 내용
- 현재 서비스 내 구현되어 있는 모달 4개(`FortuneModal.jsx`, `WithdrawModal.jsx`, `ArticleMenuModal.jsx`, `ArticleDeleteModal.jsx`)에 대해서 공통으로 분리할 수 있는 요소를 `@components/hoc/withModalBackground.jsx`로 분리하고 HoC 패턴을 적용해 리팩토링했습니다.
- 모달의 배경 부분을 눌렀을 경우 모달을 종료하도록 공통 기능을 추가했습니다.
- 모달 등장 시 애니메이션 효과를 공통 기능으로 적용헀습니다.
- 일부 모달에서 발생하는 전체 화면 시 레이아웃 버그를 수정했습니다.

## 🚨 참고 사항
- HoC 패턴 참고
  - https://ko.legacy.reactjs.org/docs/higher-order-components.html
  - https://jiyoon-park.tistory.com/entry/React-HOC에-대해-알아보자

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|모달 등장 시 애니메이션 효과 추가|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/cbad3b44-5fc9-47d9-aa59-fae4a22de720" width="300" />|
|모달 전체 화면 레이아웃 버그 수정|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/bb0ebfd7-82d5-48e7-acbf-3fcf42c1ef89" width="600px" />|
