### PR TITLE
모바일 터치 및 레이아웃 최적화

### DIFF
--- a/src/components/common/Layout.jsx
+++ b/src/components/common/Layout.jsx
@@ -11,16 +11,15 @@ import background_winter from '@assets/layout/background-winter.webp';
 
 const Container = styled.div`
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100svw;
+  height: 100svh;
 
   display: flex;
   justify-content: space-evenly;
 `;
 
 const LogoContainer = styled.div`
-  max-width: 34rem;
-
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -31,7 +30,7 @@ const LogoContainer = styled.div`
     width: 75%;
 
     padding: 0;
-    margin: 1.5rem 0 0 0;
+    margin-top: 1.5rem;
 
     img {
       width: 100%;
@@ -43,7 +42,7 @@ const LogoContainer = styled.div`
     position: relative;
 
     padding: 0;
-    margin: 1rem 0 0 0;
+    margin-top: 1rem;
 
     color: #bfbfbf;
     text-align: center;
@@ -67,15 +66,11 @@ const Logo = styled.div`
 
 const ContentContainer = styled.div`
   position: relative;
-  width: 24.375rem;
+  width: 100%;
+  max-width: 26.875rem;
   height: 100%;
 
   overflow-y: auto;
-
-  /* iOS Safari */
-  @supports (-webkit-touch-callout: none) {
-    padding-bottom: 5rem;
-  }
 
   background-color: white;
 `;

--- a/src/components/common/TabBar.jsx
+++ b/src/components/common/TabBar.jsx
@@ -3,15 +3,15 @@ import styled from 'styled-components';
 import { NavLink, useLocation } from 'react-router-dom';
 
 const Container = styled.div`
-  position: fixed;
+  position: absolute;
   bottom: 0;
 
-  width: 24.375rem;
+  width: 100%;
   height: 3.8125rem;
 
   display: flex;
-  justify-content: center;
-  gap: 3.56rem;
+  justify-content: space-between;
+  padding: 0 2.88rem;
 
   background-color: white;
 

--- a/src/components/home/YearlyContent.jsx
+++ b/src/components/home/YearlyContent.jsx
@@ -10,11 +10,15 @@ const Layout = styled.section`
   width: 100%;
   height: 100%;
 
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-x: hidden;
   overflow-y: scroll;
 `;
 
 const ContentWrapper = styled.div`
-  width: 100%;
+  width: 24.375rem;
   height: 100%;
 
   margin-top: 0.5rem;
@@ -44,19 +48,15 @@ const LastRow = styled.div`
 const Background = styled.div`
   position: absolute;
   top: -1rem;
-  width: 100%;
+  width: 24.375rem;
   height: 100%;
 
   background-color: white;
-
   z-index: 10;
 
   img {
-    /* position: absolute; */
     width: 100%;
-    /* margin-top: 1rem; */
-    /* padding: 1rem 0; */
-    /* object-fit: cover; */
+    object-fit: cover;
   }
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,7 @@
-/* iOS only */
-/* @supports (-webkit-touch-callout: none) {
-  height: -webkit-fill-available;
-} */
-
 html {
-  /* height: -webkit-fill-available; */
   /* 익스플로러 IE 10 확대 제어 */
-  /* -ms-content-zooming: none; */
-  /* -ms-touch-action: pan-x pan-y; */
+  -ms-content-zooming: none;
+  -ms-touch-action: pan-x pan-y;
 }
 
 * {
@@ -29,11 +23,9 @@ body {
   position: fixed;
   margin: 0;
   padding: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  /* height: -webkit-fill-available; */
-  min-height: 100vh;
+  min-width: 20rem;
+  width: 100svw;
+  height: 100svh;
 }
 
 a {

--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -70,6 +70,7 @@ const FortuneContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: flex-end;
+  padding: 0 1.25rem;
   margin-top: 0.2rem;
 `;
 
@@ -79,7 +80,7 @@ const Fortune = styled.div`
   justify-content: space-between;
   align-items: center;
 
-  width: 21.875rem;
+  width: 100%;
   height: 2rem;
   padding: 0 1rem;
   margin-bottom: 0.2rem;


### PR DESCRIPTION
## 📟 연결된 이슈
close #25 

## 👷 작업한 내용
- `svw`, `svh` 수치 기반으로 모바일 레이아웃을 작업했습니다.
  - 기존에 기기 별로 대응하지 않고 공통적으로 하단 패딩을 주었던 방식은 상단 툴바가 존재하는 모바일 브라우저 등에서 문제가 발생했기 때문에, CSS에 새롭게 추가된 `svw`, `svh` 값을 이용해서 최소 화면 영역을 맞추는 방식으로 개선했습니다.
- 가운데 컨테이너 영역의 최대 너비를 아이폰 15 프로 맥스 사이즈인 `26.875rem`으로 맞춰서 수정했으며, 이보다 화면 크기가 작아지는 경우 맞춰서 반응형으로 줄어들도록 적용했습니다.
- 홈 페이지의 연도별 보기만 예외로 크기를 고정값으로 주어 뒤의 배경과 엇갈리는 문제가 발생하지 않도록 했습니다.

## 🚨 참고 사항
- https://s0ojin.tistory.com/56

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|홈 - 연도별 보기|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/82103d94-1b6d-42e2-951b-f3aa9dd2c809" width="650px" />|
|홈 - 절기별 보기|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/f1844435-1359-4f03-a53a-494dffc2372e" width="650px" />|
|홈 - 운세 모달|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/5fa11ee4-6d8a-4584-8d35-4fb38a2c17b1" width="650px" />|
|콜라주 페이지|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/e40110f7-ac9c-401d-9170-681a24c7b92c" width="650px" />|
|친구 피드|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/7ff82b2d-1f62-4ffd-b17c-a15ef35db2c4" width="650px" />|
|마이 페이지|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/0a5c589a-4313-4aae-910b-399139933a94" width="650px" />|
|프로필 수정|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/5010ca39-6166-4c13-ab16-07dc19a2435a" width="650px" />|
