### PR TITLE
홈 페이지 상단 절기 기록장 기준으로 변경

### DIFF
--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -202,6 +202,10 @@ const HomePage = () => {
 
   /* 공통 */
   const [now, setNow] = useState(new Date());
+  const displayTerm =
+    termData.recordable === true
+      ? termData.recordTerm.sequence
+      : termData.currentTerm.sequence;
 
   /* 홈 */
   const searchParams = new URLSearchParams(location.search);
@@ -248,13 +252,9 @@ const HomePage = () => {
       <TopBar isNewNotification={newNotificationData} />
 
       <Season>
-        <div className="season__title">
-          {TermsToChinese[termData.currentTerm.sequence]}
-        </div>
+        <div className="season__title">{TermsToChinese[displayTerm]}</div>
         <div className="season__description">
-          {`${TermsToKorean[termData.currentTerm.sequence]}, ${
-            termData.currentTerm.sequence
-          }번째 절기`}
+          {`${TermsToKorean[displayTerm]}, ${displayTerm}번째 절기`}
         </div>
       </Season>
 


### PR DESCRIPTION
## 📟 연결된 이슈
close #34 

## 👷 작업한 내용
- `displayTerm` 변수를 분리해 표시 기준 절기를 명시했습니다.
  - `현재 기록장이 열렸을 경우 ? 열린 기록장의 절기 : 현재 날짜 기준 절기`

## 🚨 참고 사항
.

## 📸 스크린샷
.
