### PR TITLE
데스크탑 배경 화면 날짜 기준 표시

### DIFF
--- a/src/components/common/Layout.jsx
+++ b/src/components/common/Layout.jsx
@@ -96,6 +96,32 @@ function Layout() {
   // const isMobile = useMediaQuery({ maxWidth: 768 });
   const isMobile = useMediaQuery({ maxWidth: 900 });
 
+  const getBackground = () => {
+    const currentMonth = new Date().getMonth() + 1;
+
+    switch (currentMonth) {
+      case 3:
+      case 4:
+      case 5:
+        return background_spring;
+      case 6:
+      case 7:
+      case 8:
+        return background_summer;
+      case 9:
+      case 10:
+        return background_autumn;
+      case 11:
+      case 12:
+      case 1:
+      case 2:
+        return background_winter;
+
+      default:
+        break;
+    }
+  };
+
   return (
     <Container>
       {!isMobile && (
@@ -164,7 +190,7 @@ function Layout() {
       </ContentContainer>
 
       <Background>
-        <img src={background_winter} />
+        <img src={getBackground()} />
       </Background>
     </Container>
   );


### PR DESCRIPTION
## 📟 연결된 이슈
close #36 

## 👷 작업한 내용
- 현재 날짜를 통해 달을 계산한 후 11~2월은 겨울, 3~5월은 봄, 6~8월은 여름, 9~10월은 가을 배경화면이 표시되도록 수정했습니다. (`@components/common/Layout.jsx`)

## 🚨 참고 사항
.

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|예시 (봄)|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/9ee14186-9e22-4c32-904f-7c6991bf28f3" width="650px" />|
