### PR TITLE
페이지 내 무한 스크롤 구현

### DIFF
--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -69,7 +69,7 @@ const FeedPage = () => {
   const { initialFeedData } = useLoaderData();
   const [feedData, setFeedData] = useState(initialFeedData);
   const [lastFeedItemId, setLastFeedItemId] = useState(
-    initialFeedData.at(-1).article.id
+    initialFeedData.length > 0 ? initialFeedData.at(-1).article.id : null
   );
   const navigate = useNavigate();
 

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -1,15 +1,28 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 
 import FeedItem from '@components/feed/FeedItem';
 import TabBar from '@components/common/TabBar';
+import useRefFocusEffect from '@utils/hooks/useRefFocusEffect';
+
+const Layout = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
 
 const Top = styled.div`
   position: relative;
   width: 100%;
   height: 3.3125rem;
+  flex-shrink: 0;
 
   display: flex;
   justify-content: space-between;
@@ -42,7 +55,7 @@ const NavBox = styled.div`
 const ContentArea = styled.div`
   position: relative;
   width: 100%;
-  height: calc(100% - 3.3125rem);
+  flex-grow: 1;
   padding: 1.5rem 1.31rem 5.3125rem;
 
   display: flex;
@@ -55,9 +68,47 @@ const ContentArea = styled.div`
 const FeedPage = () => {
   const { initialFeedData } = useLoaderData();
   const [feedData, setFeedData] = useState(initialFeedData);
+  const [lastFeedItemId, setLastFeedItemId] = useState(
+    initialFeedData.at(-1).article.id
+  );
+  const navigate = useNavigate();
+
+  const fetchFeedData = async () => {
+    console.log(lastFeedItemId);
+    if (!lastFeedItemId) return;
+
+    const size = 10;
+
+    try {
+      const accessToken = localStorage.getItem('accessToken');
+      const feedResponse = await axios.get(
+        `/api/article/friends?size=${size}&lastId=${lastFeedItemId}`,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+      if (feedResponse.data.length === 0) {
+        setLastFeedItemId(null);
+      } else {
+        setFeedData((feedData) => [...feedData, ...feedResponse.data]);
+        setLastFeedItemId(feedResponse.data.at(-1).article.id);
+      }
+    } catch (error) {
+      console.error(error);
+
+      if (error.response && error.response.status === 401) {
+        console.log('* Unauthorized... Redirecting to /login');
+        navigate(`/login`);
+      } else {
+        console.log('* Response Error... Redirecting to /home');
+        navigate(`/home`);
+      }
+    }
+  };
+  const { focusElementRef } = useRefFocusEffect(fetchFeedData, []);
 
   return (
-    <>
+    <Layout>
       <Top>
         <h1>친구들의 24절기</h1>
         <NavBox>
@@ -108,10 +159,12 @@ const FeedPage = () => {
         {feedData.map((data, id) => (
           <FeedItem key={id} data={data} />
         ))}
+
+        <div ref={focusElementRef} />
       </ContentArea>
 
       <TabBar />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -95,6 +95,7 @@ const FeedPage = () => {
       }
     } catch (error) {
       console.error(error);
+      setLastFeedItemId(null);
 
       if (error.response && error.response.status === 401) {
         console.log('* Unauthorized... Redirecting to /login');

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -76,6 +76,7 @@ const NotificationPage = () => {
       }
     } catch (error) {
       console.error(error);
+      setLastNotificationId(null);
 
       if (error.response && error.response.status === 401) {
         console.log('* Unauthorized... Redirecting to /login');

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -45,7 +45,9 @@ const NotificationPage = () => {
   const [friendRequests, setFriendRequests] = useState([]);
   const [otherNotifications, setOtherNotifications] = useState([]);
   const [lastNotificationId, setLastNotificationId] = useState(
-    initialNotificationData.at(-1).id
+    initialNotificationData.length > 0
+      ? initialNotificationData.at(-1).id
+      : null
   );
   const navigate = useNavigate();
 

--- a/src/pages/notification/NotificationPage.jsx
+++ b/src/pages/notification/NotificationPage.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import styled from 'styled-components';
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 
+import useRefFocusEffect from '@utils/hooks/useRefFocusEffect';
 import NavigationHeader from '@components/common/NavigationHeader';
 import FriendRequest from '@components/notification/FriendRequest';
 import FriendReaction from '@components/notification/FriendReaction';
@@ -42,6 +44,47 @@ const NotificationPage = () => {
   const [notifications, setNotifications] = useState(initialNotificationData);
   const [friendRequests, setFriendRequests] = useState([]);
   const [otherNotifications, setOtherNotifications] = useState([]);
+  const [lastNotificationId, setLastNotificationId] = useState(
+    initialNotificationData.at(-1).id
+  );
+  const navigate = useNavigate();
+
+  const fetchNotificationData = async () => {
+    console.log(lastNotificationId);
+    if (!lastNotificationId) return;
+
+    const size = 20;
+
+    try {
+      const accessToken = localStorage.getItem('accessToken');
+      const notiResponse = await axios.get(
+        `/api/notification?size=${size}&lastId=${lastNotificationId}`,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+      if (notiResponse.data.length === 0) {
+        setLastNotificationId(null);
+      } else {
+        setNotifications((notifications) => [
+          ...notifications,
+          ...notiResponse.data,
+        ]);
+        setLastNotificationId(notiResponse.data.at(-1).id);
+      }
+    } catch (error) {
+      console.error(error);
+
+      if (error.response && error.response.status === 401) {
+        console.log('* Unauthorized... Redirecting to /login');
+        navigate(`/login`);
+      } else {
+        console.log('* Response Error... Redirecting to /home');
+        navigate(`/home`);
+      }
+    }
+  };
+  const { focusElementRef } = useRefFocusEffect(fetchNotificationData, []);
 
   useEffect(() => {
     setFriendRequests(
@@ -127,6 +170,8 @@ const NotificationPage = () => {
               return undefined;
           }
         })}
+
+        <div ref={focusElementRef} />
       </NotificationContainer>
     </Layout>
   );

--- a/src/utils/api/FeedLoader.jsx
+++ b/src/utils/api/FeedLoader.jsx
@@ -1,9 +1,6 @@
 import axios from 'axios';
 import { redirect } from 'react-router-dom';
 
-const size = 1;
-const articleId = 1;
-
 export const FeedLoader = async ({ request, params }) => {
   /* (공통 로직) localStorage에 “accessToken” 이 존재하지 않는 경우 처리 */
   const accessToken = localStorage.getItem('accessToken');
@@ -11,15 +8,12 @@ export const FeedLoader = async ({ request, params }) => {
     console.log('* No Access Token... Redirecting to /login');
     return redirect(`/login`);
   }
+  const size = 10;
 
   try {
-    const feedResponse = await axios.get(
-      // `/api/article/friends?size=${size}&lastId=${articleId}`,
-      `/api/article/friends`,
-      {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      }
-    );
+    const feedResponse = await axios.get(`/api/article/friends?size=${size}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
     return { initialFeedData: feedResponse.data };
   } catch (error) {
     console.error(error);

--- a/src/utils/api/HomeLoader.jsx
+++ b/src/utils/api/HomeLoader.jsx
@@ -23,7 +23,7 @@ export const HomeLoader = async ({ request, params }) => {
     const homeResponse = await axios.get(
       category === 'year'
         ? `/api/article/list/year/${year}`
-        : `/api/article/list/term?term=${term}`,
+        : `/api/article/list/term?term=${term}&size=20`,
       {
         headers: { Authorization: `Bearer ${accessToken}` },
       }

--- a/src/utils/api/NotificationLoader.jsx
+++ b/src/utils/api/NotificationLoader.jsx
@@ -8,13 +8,11 @@ export const NotificationLoader = async ({ request, params }) => {
     console.log('* No Access Token... Redirecting to /login');
     return redirect(`/login`);
   }
-
-  const size = 10;
-  const lastId = '';
+  const size = 20;
 
   try {
     const notificationResponse = await axios.get(
-      `/api/notification?size=${size}&lastId=${lastId}`,
+      `/api/notification?size=${size}`,
       {
         headers: { Authorization: `Bearer ${accessToken}` },
       }

--- a/src/utils/hooks/useRefFocusEffect.jsx
+++ b/src/utils/hooks/useRefFocusEffect.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+export default function useRefFocusEffect(onFocusCallback, deps) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      const observer = new IntersectionObserver(
+        (entries) =>
+          entries.forEach((entry) => entry.isIntersecting && onFocusCallback()),
+        {
+          threshold: 1,
+        }
+      );
+      observer.observe(ref.current);
+      return () => {
+        if (ref.current) observer.unobserve(ref.current);
+      };
+    }
+  }, [deps]);
+
+  return { focusElementRef: ref };
+}


### PR DESCRIPTION
## 📟 연결된 이슈
close #39 

## 👷 작업한 내용
- Intersection Observer API를 이용해 어떤 요소가 뷰포트 안에 들어왔을 때 콜백 함수를 호출하는 로직을 커스텀 훅으로 분리했습니다. 아래와 같이 사용합니다.
  ```javascript
  // pages/FeedPage.jsx
  const { focusElementRef } = useRefFocusEffect(callBack: 콜백 함수, []: 의존성 배열);
  ```
- 알림 페이지, 친구 피드 페이지에서 무한 스크롤 기능을 적용했습니다.
  - 한 번에 불러오는 `size`는 알림의 경우 20, 친구 피드 페이지의 경우 10으로 요청했습니다.
  - 콜백 함수에서는 json 응답 데이터의 마지막 아이템의 식별자를 `lastFetchItemId`에 업데이트하고, 페이지네이션의 마지막 아이템을 호출한 경우 이 값은 `null`로 바뀌어 더 이상 fetch 요청이 발생하는 것을 막습니다.
    ```javascript
    // pages/FeedPage.jsx
    if (feedResponse.data.length === 0) {
        setLastFeedItemId(null);
    } else {
        setFeedData((feedData) => [...feedData, ...feedResponse.data]);
        setLastFeedItemId(feedResponse.data.at(-1).article.id);
    }
    ```

## 🚨 참고 사항
- 무한 스크롤 동작을 감지하는 원리와, Intersection Observer API를 이용하는 이유를 이해하는 데  참고하기 좋은 링크입니다.
  https://tech.kakaoenterprise.com/149

## 📸 스크린샷
|페이지|스크린샷|
|:--:|:--:|
|알림 페이지|<img src = "https://github.com/Seasoning-Today/frontend/assets/6462456/a765defd-2ed3-4684-8189-5d3cc8c97c11" width="300" />|
